### PR TITLE
Fix byte-compilation warning.

### DIFF
--- a/crm-custom.el
+++ b/crm-custom.el
@@ -105,7 +105,7 @@ in `completing-read-multiple'."
          ;; Record successful result
          do (setq success t
                   ad-return-value (or return-list def-list))
-         and return
+         and return nil
          ;; Collect selected item and go again
          else
          collect next-value into return-list


### PR DESCRIPTION
Byte-compiling the package would give a warning about else being a free
variable. This is due to a misuse of the return form in loop, which
should have a value to return after it.