### PR TITLE
Don't set obsoleted variable.

### DIFF
--- a/crm-custom.el
+++ b/crm-custom.el
@@ -81,8 +81,6 @@ in `completing-read-multiple'."
          ;; Save original prompt and construct prompt with defaults
          with orig-prompt = prompt
          with prompt = (concat orig-prompt def-text)
-         ;; Enable entry of empty string with ido
-         with ido-ubiquitous-enable-old-style-default = nil
          ;; Pre-expand completions table
          with table = (delete-dups
                        (nconc def-list-no-empty-string


### PR DESCRIPTION
This was causing byte-compilation warnings for the package. The modern
default value of ido-ubiquitous-default-state maps to the nil value of
the deprecated setting.